### PR TITLE
Preserve blanks and uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ assert.deepEqual(
   { content: [ 'A' ] })
 ```
 
-Converts term uses to strings:
+Passes term uses through:
 
 ```javascript
 assert.deepEqual(
   resolve(
     { content: [ { use: 'A' } ] },
     { }),
-  { content: [ 'A' ] })
+  { content: [ { use: 'A' } ] })
 ```
 
 Passes definitions through:
@@ -34,14 +34,14 @@ assert.deepEqual(
   { content: [ { definition: 'A' } ] })
 ```
 
-Replaces blanks with provided values, or a blank when none are provided:
+Provides blank values:
 
 ```javascript
 assert.deepEqual(
   resolve(
     { content: [ { blank: 'A' } ] },
     { A: '1' }),
-  { content: [ '1' ] })
+  { content: [ { blank: 'A', value: '1' } ] })
 
 assert.deepEqual(
   resolve(
@@ -99,19 +99,6 @@ assert.deepEqual(
             element: { number: 1, of: 2 } } ],
         [ { series:  { number: 1, of: 1 },
             element: { number: 2, of: 2 } } ] ] } )
-
-```
-
-Concatenates strings and contiguous objects that are resolved to strings:
-
-```javascript
-assert.deepEqual(
-  resolve({ content: [ 'A', { use: 'B' } ] }, { }).content,
-  [ 'AB' ])
-
-assert.deepEqual(
-  resolve({ content: [ { use: 'A' }, 'B' ] }, { }).content,
-  [ 'AB' ])
 
 ```
 

--- a/element.js
+++ b/element.js
@@ -7,7 +7,7 @@ module.exports = function(element, values, numbering, headings) {
   if (predicate.text(element)) {
     return element }
   else if (predicate.use(element)) {
-    return element.use }
+    return element }
   else if (predicate.child(element)) {
     element.numbering = numbering.numbering
     element.form = resolve(
@@ -44,9 +44,9 @@ module.exports = function(element, values, numbering, headings) {
     var value = element.blank
     // Filled
     if (values.hasOwnProperty(value)) {
-      return values[value] }
+      return { blank: value, value: values[value] } }
     // Empty
     else {
-      return {blank: value} } }
+      return { blank: value } } }
   else {
     throw new Error('Invalid content: ' + JSON.stringify(element)) } }

--- a/form.js
+++ b/form.js
@@ -2,7 +2,6 @@ var resolveElement = require('./element')
 
 module.exports = function(form, values, numberings, headings) {
   form.content = form.content
-    // resolve content
     .map(function(element, index) {
       var numbering = (
         ( numberings &&
@@ -10,20 +9,5 @@ module.exports = function(form, values, numberings, headings) {
           numberings.content.hasOwnProperty(index) ) ?
         numberings.content[index] : null )
       return resolveElement(element, values, numbering, headings) })
-
-    // Concatenate contiguous strings.
-    .reduce(
-      function(content, element, index) {
-        var count = content.length
-        var last = content[count - 1]
-        if (
-          index > 0 &&
-          typeof element === 'string' &&
-          typeof last === 'string')
-        { content[count - 1] = last + element }
-        else {
-          content.push(element) }
-        return content },
-      [])
 
   return form }


### PR DESCRIPTION
This PR changes the package to return `{use: "Term"}` and `{blank: "Blank", value: "Value"}` when appropriate, rather than converting those content elements to strings.

This will allow renderers to style term uses and blanks, filled or unfilled.

It's a SemVer breaking change.

cc: @anseljh
